### PR TITLE
Function to retrieve exit code from ExecOperation

### DIFF
--- a/dockerpty/__init__.py
+++ b/dockerpty/__init__.py
@@ -35,13 +35,16 @@ def exec_command(
     """
     Run provided command via exec API in provided container.
 
-    This is just a wrapper for PseudoTerminal(client, container).exec_command()
+    This is just a wrapper for PseudoTerminal(client, container).exec_command().
+    Also returns the exit_code of the operation.
     """
     exec_id = exec_create(client, container, command, interactive=interactive)
 
     operation = ExecOperation(client, exec_id,
                               interactive=interactive, stdout=stdout, stderr=stderr, stdin=stdin)
     PseudoTerminal(client, operation).start()
+
+    return operation.exit_code()
 
 
 def start_exec(client, exec_id, interactive=True, stdout=None, stderr=None, stdin=None):

--- a/dockerpty/pty.py
+++ b/dockerpty/pty.py
@@ -275,6 +275,12 @@ class ExecOperation(Operation):
         """
         return self._exec_info()["ProcessConfig"]["tty"]
 
+    def exit_code(self):
+        """
+        returns the exit code of execed process if complete
+        """
+        return self.client.api.exec_inspect(self.exec_id)['ExitCode']
+
     def _exec_info(self):
         """
         Caching wrapper around client.exec_inspect


### PR DESCRIPTION
Very simple helper function, just pulling the `ExitCode` from the params returned by the Docker API.
Also returning that exit code in the `exec_command` wrapper for convenience.